### PR TITLE
Add Trailing Slash to Directories

### DIFF
--- a/src/fileGatherer.ts
+++ b/src/fileGatherer.ts
@@ -21,7 +21,7 @@ export default class FileGatherer {
         // Make this async
         files.filter(file => fs.statSync(directory + "/" + file).isDirectory())
             .forEach((directory) => {
-                directories.push(this.produceBarellableName(directory, true));
+                directories.push(this.produceBarellableName(directory + '/', true));
         });
 
         // Make this async


### PR DESCRIPTION
Since there can be a file named card.ts and a directory named card that would cause a resource conflict, all directories exported need to have a trailing slash.