### PR TITLE
Allow configuration of barreled file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
                     "type": "string",
                     "default": "(\\.spec\\.|\\.test\\.|\\.e2e\\.)",
                     "description": "Regular expression for excluding files or folders from barrels."
+                },
+                "barrelr.fileExtensionRegex": {
+                    "type": "string",
+                    "default": "\\.tsx?$",
+                    "description": "Regular expression for file extensions that will be included in barrels."
                 }
             }
         }

--- a/src/fileGatherer.ts
+++ b/src/fileGatherer.ts
@@ -25,12 +25,12 @@ export default class FileGatherer {
         });
 
         // Make this async
-        files.filter(file => fs.statSync(directory + "/" + file).isFile())
-            .filter(file => file !== "index.ts")
-                .filter(file => path.extname(file) === ".ts")
-                    .filter(file => !file.match(this.getExcludeRegEx()))
-                    .forEach((file) => {
-                        outputFiles.push(this.produceBarellableName(file, false));
+        files.filter(file => fs.statSync(directory + "/" + file).isFile()
+            && file !== "index.ts"
+            && path.extname(file).match(this.getExtensionsRegEx())
+            && !file.match(this.getExcludeRegEx())
+        ).forEach((file) => {
+            outputFiles.push(this.produceBarellableName(file, false));
         });
 
         return directories.concat(outputFiles);
@@ -44,9 +44,14 @@ export default class FileGatherer {
         }
     }
 
-    private getExcludeRegEx() {
+    private getExcludeRegEx(): string {
         const config = vscode.workspace.getConfiguration("barrelr");
         return config["excludeFileRegex"];
+    }
+
+    private getExtensionsRegEx(): string {
+        const config = vscode.workspace.getConfiguration("barrelr");
+        return config["fileExtensionRegex"];
     }
 
 }

--- a/test/fileGatherer.test.ts
+++ b/test/fileGatherer.test.ts
@@ -7,7 +7,8 @@ import FileGatherer from "../src/fileGatherer";
 suite("File Gatherer Tests", () => {
     let fileGatherer: FileGatherer
     let fsStatSync: Sinon.SinonStub;
-    let getExcludeRegEx: Sinon.SinonStub;;
+    let getExcludeRegEx: Sinon.SinonStub;
+    let getExtensionsRegEx: Sinon.SinonStub;
     const directoryObject = { isDirectory() {return true}, isFile() {return false}}
     const fileObject = { isDirectory() {return false}, isFile() {return true}}
 
@@ -15,6 +16,8 @@ suite("File Gatherer Tests", () => {
         fileGatherer = new FileGatherer();
         getExcludeRegEx = Sinon.stub(fileGatherer, "getExcludeRegEx");
         getExcludeRegEx.returns("(\\.spec\\.|\\.test\\.|\\.e2e\\.)");
+        getExtensionsRegEx = Sinon.stub(fileGatherer, "getExtensionsRegEx");
+        getExtensionsRegEx.returns("\\.tsx?$");
         fsStatSync = Sinon.stub(fs, "statSync");
         fsStatSync.withArgs("C:/Mike/folder").returns(directoryObject);
         fsStatSync.withArgs("C:/Mike/secondFolder").returns(directoryObject);
@@ -25,6 +28,7 @@ suite("File Gatherer Tests", () => {
         fsStatSync.withArgs("C:/Mike/image.png").returns(fileObject);
         fsStatSync.withArgs("C:/Mike/file.test.ts").returns(fileObject);
         fsStatSync.withArgs("C:/Mike/file.spec.ts").returns(fileObject);
+        fsStatSync.withArgs("C:/Mike/file.abc").returns(fileObject);
     })
 
     test("Given Directory, produce barellable name should produce correct format", () => {
@@ -66,6 +70,13 @@ suite("File Gatherer Tests", () => {
     test("Given list of files including spec.ts files, produceBarreledNames should produce correct array of files and folders without spec files", () => {
         const returnedFileNames = fileGatherer.produceBarreledNames(["file.ts", "file.spec.ts"], "C:/Mike");
         const expectedFileNames = ["./file"];
+        assert.deepStrictEqual(returnedFileNames, expectedFileNames);
+    });
+
+    test("Given list of files with various extensions, produceBarreledNames uses fileExtensionRegex config setting to produce array of files with matching extensions", () => {
+        getExtensionsRegEx.returns("\\.abc$");
+        const returnedFileNames = fileGatherer.produceBarreledNames(["file.ts", "secondFile.ts", "file.abc"], "C:/Mike");
+        const expectedFileNames = ["./file.abc"];
         assert.deepStrictEqual(returnedFileNames, expectedFileNames);
     });
 });


### PR DESCRIPTION
First of all, thanks for writing this extension 👍 

Most of what my team and I work with are `.tsx` files (React’s JSX for TypeScript), which this extension didn’t pick up. I’ve updated it to pick them up by default, and also made the setting configurable.

Let me know what you think!