### PR TITLE
chore: bump dependencies and get tests to compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,10 @@
         },
         "barrelr.lineEnding": {
           "type": "string",
-          "enum": ["CRLF", "LF"],
+          "enum": [
+            "CRLF",
+            "LF"
+          ],
           "default": "CRLF",
           "description": "Select line ending to use"
         },
@@ -80,14 +83,14 @@
     "test": "node ./node_modules/vscode/bin/test"
   },
   "devDependencies": {
-    "@types/mocha": "^2.2.38",
-    "@types/node": "^6.0.40",
-    "@types/sinon": "^1.16.33",
-    "mocha": "^2.3.3",
-    "sinon": "^1.17.6",
-    "tslint": "^5.11.0",
-    "typescript": "^2.1.5",
-    "vscode": "^1.0.0"
+    "@types/mocha": "^8.0.3",
+    "@types/node": "^14.6.3",
+    "@types/sinon": "^9.0.5",
+    "mocha": "^8.1.3",
+    "sinon": "^9.0.3",
+    "tslint": "^6.1.3",
+    "typescript": "^4.0.2",
+    "vscode": "^1.1.37"
   },
   "dependencies": {}
 }

--- a/test/barrelProducer.test.ts
+++ b/test/barrelProducer.test.ts
@@ -12,9 +12,9 @@ suite("Barrel Producer Tests", () => {
 
   suiteSetup(() => {
     barrelProducer = new BarrelProducer("./", []);
-    getQuoteMark = Sinon.stub(barrelProducer, "getQuoteMark");
-    getSemiColon = Sinon.stub(barrelProducer, "getSemiColon");
-    getLineEnding = Sinon.stub(barrelProducer, "getLineEnding");
+    getQuoteMark = Sinon.stub(barrelProducer as any, "getQuoteMark");
+    getSemiColon = Sinon.stub(barrelProducer as any, "getSemiColon");
+    getLineEnding = Sinon.stub(barrelProducer as any, "getLineEnding");
   });
 
   setup(() => {

--- a/test/fileGatherer.test.ts
+++ b/test/fileGatherer.test.ts
@@ -14,9 +14,9 @@ suite("File Gatherer Tests", () => {
 
   suiteSetup(() => {
     fileGatherer = new FileGatherer();
-    getExcludeRegEx = Sinon.stub(fileGatherer, "getExcludeRegEx");
+    getExcludeRegEx = Sinon.stub(fileGatherer as any, "getExcludeRegEx");
     getExcludeRegEx.returns("(\\.spec\\.|\\.test\\.|\\.e2e\\.)");
-    getExtensionsRegEx = Sinon.stub(fileGatherer, "getExtensionsRegEx");
+    getExtensionsRegEx = Sinon.stub(fileGatherer as any, "getExtensionsRegEx");
     getExtensionsRegEx.returns(".tsx?$");
     fsStatSync = Sinon.stub(fs, "statSync");
     fsStatSync.withArgs("C:/Mike/folder").returns(directoryObject);


### PR DESCRIPTION
Hi, looks like the latest version with support for mac/linux line endings never got published due to tests failing. I've bumped some deps and modified the test files to allow accessing the private methods and the tests pass for me now. It'd be nice to get the latest version published so lmk if there's anything else I need to do. Cheers.